### PR TITLE
Adjust #line when generating .cpp file from .ino

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -315,6 +315,7 @@ else
 applet/$(TARGET).cpp: $(TARGET).ino
 	test -d applet || mkdir applet
 	echo '#include "Arduino.h"' > applet/$(TARGET).cpp
+	echo '#line 1 "$(TARGET).ino"' >> applet/$(TARGET).cpp
 	cat $(TARGET).ino >> applet/$(TARGET).cpp
 	echo 'extern "C" void __cxa_pure_virtual() { while (1) ; }' >> applet/$(TARGET).cpp
 	cat $(ARDUINO_CORE)/main.cpp >> applet/$(TARGET).cpp

--- a/blink/blink.ino
+++ b/blink/blink.ino
@@ -1,5 +1,4 @@
 /* -*- c -*- */
-#line 3
 
 /*
  * Arduino basic blink

--- a/motors/servo/servo.ino
+++ b/motors/servo/servo.ino
@@ -1,5 +1,4 @@
 /* -*- c -*- */
-#line 3
 
 #include <Servo.h>
  

--- a/sunflower/sunflower.ino
+++ b/sunflower/sunflower.ino
@@ -1,6 +1,5 @@
 /* Sunflower sketch: turn in the direction the light is brightest.
  */
-#line 3
 
 #include <Stepper.h>
 


### PR DESCRIPTION
Fixup the generated .cpp file to get correct file and line info for
error message.  Not tested - I don't actually have an Arduino yet :)
